### PR TITLE
fix(log): implement FromContext for request-scoped loggers

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -48,7 +48,15 @@ func parseLevel(s string) slog.Level {
 
 type loggerContextKey struct{}
 
-func FromContext(context.Context) *slog.Logger {
+func FromContext(ctx context.Context) *slog.Logger {
+	if ctx == nil {
+		return slog.Default()
+	}
+	if v := ctx.Value(loggerContextKey{}); v != nil {
+		if l, ok := v.(*slog.Logger); ok && l != nil {
+			return l
+		}
+	}
 	return slog.Default()
 }
 

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1,6 +1,9 @@
 package log
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"log/slog"
 	"testing"
 
@@ -68,4 +71,37 @@ func TestInit(t *testing.T) {
 			logger.Info("test message", "test_key", "test_value")
 		})
 	}
+}
+
+func TestFromContext(t *testing.T) {
+	t.Run("nil context uses default", func(t *testing.T) {
+		def := slog.Default()
+		got := FromContext(nil)
+		if got != def {
+			t.Fatalf("FromContext(nil) = %p, want default %p", got, def)
+		}
+	})
+
+	t.Run("empty context uses default", func(t *testing.T) {
+		def := slog.Default()
+		got := FromContext(context.Background())
+		if got != def {
+			t.Fatalf("FromContext(bg) = %p, want default %p", got, def)
+		}
+	})
+
+	t.Run("returns logger attached with WithLogger", func(t *testing.T) {
+		var buf bytes.Buffer
+		h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+		custom := slog.New(h)
+		ctx := WithLogger(context.Background(), custom)
+		FromContext(ctx).Info("hello", "k", "v")
+		var m map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+			t.Fatalf("log line: %q", buf.String())
+		}
+		if m["msg"] != "hello" || m["k"] != "v" {
+			t.Fatalf("unexpected payload: %v", m)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- `FromContext` now returns the logger installed with `WithLogger`, falling back to `slog.Default()` when absent.
- Adds unit tests covering nil context, empty context, and a custom JSON handler.

## Test plan
- [x] `go test ./log/...`

Related: OPE-79 follow-up implementation (stack item: context logger propagation).

Made with [Cursor](https://cursor.com)