### PR TITLE
feat(store/gorm): wire GetDB to core SQL store (MySQL)

### DIFF
--- a/internal/store/gorm.go
+++ b/internal/store/gorm.go
@@ -1,1 +1,28 @@
 package store
+
+import (
+	"strings"
+
+	"butterfly.orx.me/core/internal/config"
+	gormstore "butterfly.orx.me/core/store/gorm"
+)
+
+// InitGORM registers GORM handles for MySQL entries in core store config,
+// reusing the *sql.DB pools created by InitSQLDB. PostgreSQL configs are
+// skipped until a GORM postgres driver is added to the module.
+func InitGORM() error {
+	for name, dbCfg := range config.CoreConfig().Store.DB {
+		d := strings.ToLower(strings.TrimSpace(dbCfg.Driver))
+		if d == "postgres" || d == "postgresql" {
+			continue
+		}
+		sqlDB := GetSQLDB(name)
+		if sqlDB == nil {
+			continue
+		}
+		if err := gormstore.RegisterFromSQL(name, sqlDB); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -9,6 +9,10 @@ func Init() error {
 	if err != nil {
 		return err
 	}
+	err = InitGORM()
+	if err != nil {
+		return err
+	}
 	err = InitMongo()
 	if err != nil {
 		return err

--- a/store/gorm/gorm.go
+++ b/store/gorm/gorm.go
@@ -1,6 +1,10 @@
 package gorm
 
 import (
+	"database/sql"
+	"fmt"
+	"sync"
+
 	// mysql driver
 	_ "github.com/go-sql-driver/mysql"
 	"gorm.io/driver/mysql"
@@ -13,6 +17,35 @@ type DB = gorm.DB
 type Session = gorm.Session
 
 type Tx = gorm.Tx
+
+var (
+	gormDBs   = make(map[string]*DB)
+	gormDBsMu sync.RWMutex
+)
+
+// RegisterFromSQL wires a *sql.DB opened by the core SQL store (MySQL driver)
+// into a GORM handle named name. It is idempotent per process: the last
+// registration for a given name wins. Call during application init only.
+func RegisterFromSQL(name string, sqlDB *sql.DB) error {
+	if name == "" {
+		return fmt.Errorf("gorm: empty store name")
+	}
+	if sqlDB == nil {
+		return fmt.Errorf("gorm: nil sql DB for %q", name)
+	}
+	dialector := mysql.New(mysql.Config{Conn: sqlDB})
+	db, err := gorm.Open(dialector, &gorm.Config{})
+	if err != nil {
+		return fmt.Errorf("gorm: open %q: %w", name, err)
+	}
+	if err := db.Use(tracing.NewPlugin()); err != nil {
+		return fmt.Errorf("gorm: otel plugin %q: %w", name, err)
+	}
+	gormDBsMu.Lock()
+	gormDBs[name] = db
+	gormDBsMu.Unlock()
+	return nil
+}
 
 // NewDB
 // MySQL only for now
@@ -28,6 +61,8 @@ func NewDB(dsn string) (*DB, error) {
 	return db, nil
 }
 
-func GetDB(_ string) *DB {
-	return nil
+func GetDB(name string) *DB {
+	gormDBsMu.RLock()
+	defer gormDBsMu.RUnlock()
+	return gormDBs[name]
 }


### PR DESCRIPTION
## Summary
- After `InitSQLDB`, `InitGORM` opens GORM on the shared `*sql.DB` pool for each configured MySQL store entry and registers it by name.
- `store/gorm.GetDB(name)` returns the registered handle; PostgreSQL configs are skipped until a Postgres GORM driver is added.
- Adds `RegisterFromSQL` for explicit registration paths.

## Test plan
- [x] `go build ./...`

Related: OPE-79 follow-up (GORM `GetDB` + global store).

Made with [Cursor](https://cursor.com)