### PR TITLE
feat(otel): trace sampling from core config

### DIFF
--- a/internal/observe/tracing/otel.go
+++ b/internal/observe/tracing/otel.go
@@ -6,7 +6,9 @@ import (
 	"log/slog"
 
 	"butterfly.orx.me/core/internal/arg"
+	"butterfly.orx.me/core/internal/config"
 	"butterfly.orx.me/core/internal/runtime"
+	"butterfly.orx.me/core/mod"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -75,8 +77,9 @@ func Init() error {
 	// Register the trace exporter with a TracerProvider, using a batch
 	// span processor to aggregate spans before export.
 	bsp := sdktrace.NewBatchSpanProcessor(traceExporter)
+	sampler := traceSamplerFromConfig(config.CoreConfig().Otel)
 	tracerProvider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSampler(sampler),
 		sdktrace.WithResource(res),
 		sdktrace.WithSpanProcessor(bsp),
 	)
@@ -85,6 +88,20 @@ func Init() error {
 	// set global propagator to tracecontext (the default is no-op).
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 
-	// Shutdown will flush any remaining spans and shut down the exporter.
-	return err
+	return nil
+}
+
+func traceSamplerFromConfig(cfg mod.OtelConfig) sdktrace.Sampler {
+	ratio := 1.0
+	if cfg.TraceSampleRatio != nil {
+		ratio = *cfg.TraceSampleRatio
+	}
+	switch {
+	case ratio <= 0:
+		return sdktrace.NeverSample()
+	case ratio >= 1:
+		return sdktrace.AlwaysSample()
+	default:
+		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(ratio))
+	}
 }

--- a/internal/observe/tracing/otel_sampler_test.go
+++ b/internal/observe/tracing/otel_sampler_test.go
@@ -1,0 +1,31 @@
+package tracing
+
+import (
+	"testing"
+
+	"butterfly.orx.me/core/mod"
+)
+
+func float64Ptr(v float64) *float64 { return &v }
+
+func TestTraceSamplerFromConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  mod.OtelConfig
+	}{
+		{"nil ratio defaults to always", mod.OtelConfig{}},
+		{"explicit always", mod.OtelConfig{TraceSampleRatio: float64Ptr(1)}},
+		{"above one treated as always", mod.OtelConfig{TraceSampleRatio: float64Ptr(2)}},
+		{"zero is never", mod.OtelConfig{TraceSampleRatio: float64Ptr(0)}},
+		{"negative is never", mod.OtelConfig{TraceSampleRatio: float64Ptr(-0.5)}},
+		{"fraction uses parent based ratio", mod.OtelConfig{TraceSampleRatio: float64Ptr(0.25)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := traceSamplerFromConfig(tt.cfg)
+			if s == nil {
+				t.Fatal("sampler is nil")
+			}
+		})
+	}
+}

--- a/mod/config.go
+++ b/mod/config.go
@@ -20,6 +20,11 @@ type StoreConfig struct {
 }
 
 type OtelConfig struct {
+	// TraceSampleRatio is the fraction of root spans to record when tracing
+	// is enabled. Valid range is 0.0–1.0. When nil or >= 1, all spans are
+	// kept (AlwaysSample). When <= 0, no spans are recorded (NeverSample).
+	// Values between 0 and 1 use ParentBased(TraceIDRatioBased(ratio)).
+	TraceSampleRatio *float64 `yaml:"trace_sample_ratio"`
 }
 
 type MongoConfig struct {


### PR DESCRIPTION
## Summary
- Adds `otel.trace_sample_ratio` to `mod.OtelConfig` (YAML). When unset or `>= 1`, behavior matches previous `AlwaysSample`; `<= 0` uses `NeverSample`; otherwise `ParentBased(TraceIDRatioBased(ratio))`.
- Fixes `tracing.Init` to return `nil` on success (previously returned the last exporter error variable).

## Test plan
- [x] `go test ./internal/observe/tracing/...`
- [x] `go build ./...`

Related: OPE-79 follow-up (configurable sampling instead of always-on).

Made with [Cursor](https://cursor.com)